### PR TITLE
updated for refactor(Core/Unit): clean MonsterTExt methods #6957

### DIFF
--- a/src/npc_enchanter.cpp
+++ b/src/npc_enchanter.cpp
@@ -325,7 +325,7 @@ public:
             item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
             if (!item)
             {
-                creature->MonsterWhisper("This enchant requires a 2H weapon to be equipped.", player, 0);
+                creature->Whisper("This enchant requires a 2H weapon to be equipped.", LANG_UNIVERSAL, player);
                 player->PlayerTalkClass->SendCloseGossip();
                 return false;
             }
@@ -341,7 +341,7 @@ public:
             }
             else
             {
-                creature->MonsterWhisper("This enchant requires a 2H weapon to be equipped.", player, 0);
+                creature->Whisper("This enchant requires a 2H weapon to be equipped.", LANG_UNIVERSAL, player);
                 player->PlayerTalkClass->SendCloseGossip();
             }
             player->PlayerTalkClass->SendGossipMenu(100003, creature->GetGUID());
@@ -352,7 +352,7 @@ public:
             item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
             if (!item)
             {
-                creature->MonsterWhisper("This enchant requires a shield to be equipped.", player, 0);
+                creature->Whisper("This enchant requires a shield to be equipped.", LANG_UNIVERSAL, player);
                 player->PlayerTalkClass->SendCloseGossip();
                 return false;
             }
@@ -368,7 +368,7 @@ public:
             }
             else
             {
-                creature->MonsterWhisper("This enchant requires a shield to be equipped.", player, 0);
+                creature->Whisper("This enchant requires a shield to be equipped.", LANG_UNIVERSAL, player);
                 player->PlayerTalkClass->SendGossipMenu(100004, creature->GetGUID());
 
             }
@@ -984,7 +984,7 @@ public:
         if (!item)
         {
             creature->HandleEmoteCommand(EMOTE_ONESHOT_LAUGH);
-            creature->MonsterWhisper("Please equip the item you would like to enchant!", player, 0);
+            creature->Whisper("Please equip the item you would like to enchant!", LANG_UNIVERSAL, player);
             player->PlayerTalkClass->SendCloseGossip();
             return;
         }
@@ -1046,7 +1046,7 @@ public:
                 if (MessageTimer <= diff)
                 {
                     std::string Message = PickPhrase();
-                    me->MonsterSay(Message.c_str(), LANG_UNIVERSAL, NULL);
+                    me->Say(Message.c_str(), LANG_UNIVERSAL);
 
                     // Use gesture?
                     if (EnchanterEmoteCommand != 0)


### PR DESCRIPTION
**Changes Proposed:**

- Updates all "monsterwhisper" and "monstersay" dialogue to match subject PR from main repo
https://github.com/azerothcore/azerothcore-wotlk/pull/6957

**Tests Performed**

- this module started to fail build after subject PR was merged
- Now build finishes without error and server launches
![npc](https://user-images.githubusercontent.com/36058236/137640231-f443ffea-0e34-4d17-8703-dfded7152758.PNG)
- tested in game and dialogue works
![enchanter](https://user-images.githubusercontent.com/36058236/137640494-c6db1fde-932f-479b-95ea-b7c16a4a51dd.PNG)

**How to test**

1. build with PR
2. .npc add 601015
3. go thru dialogue options to make sure the options work
